### PR TITLE
enable additional net interface, if present

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "exoscale_compute" "this" {
   count = var.instance_count
 
   key_pair        = var.key_pair
-  display_name    = var.instance_count == 1 ? var.display_name : format("%s-%s", var.display_name, count.index)
+  display_name    = var.display_name != "" ? format("%s-%s", var.display_name, count.index) : format("ip-%s", join("-", split(".", cidrhost(var.private_network.cidr, var.private_network.offset + count.index))))
   disk_size       = var.root_disk_size
   security_groups = var.security_groups
   size            = var.size

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,11 @@ output "this_instance_hostname" {
     format("%s.%s", instance_name, var.domain)
   ]
 }
+
+output "this_instance_private_ipv4" {
+  description = "Instance's private IPv4"
+  value = var.private_network != null ? [
+    for i in range(var.instance_count) :
+      cidrhost(var.private_network.cidr, lookup(var.private_network, "offset", 10) + i)
+  ] : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,8 @@ variable "security_groups" {
 }
 
 variable "display_name" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "size" {


### PR DESCRIPTION
By default, additional exoscale_network resources aren't managed, so the
interface stays down. Adding this snippet to cloud-init, fix this, as per
https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html#network-config-v1
I chose the "Network Config Version 1" format, which seems to be
supported by the usual distros we deploy.